### PR TITLE
feat: macOS notification escalation (v0.5.0) (#19)

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Run HeyDev Extension",
+      "type": "extensionHost",
+      "request": "launch",
+      "args": [
+        "--extensionDevelopmentPath=${workspaceFolder}"
+      ],
+      "outFiles": ["${workspaceFolder}/out/**/*.js"],
+      "preLaunchTask": "npm: compile"
+    }
+  ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,26 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "type": "npm",
+      "script": "compile",
+      "problemMatcher": "$tsc",
+      "presentation": {
+        "reveal": "silent"
+      },
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      }
+    },
+    {
+      "type": "npm",
+      "script": "watch",
+      "problemMatcher": "$tsc-watch",
+      "isBackground": true,
+      "presentation": {
+        "reveal": "never"
+      }
+    }
+  ]
+}

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,5 +1,14 @@
 .vscode/**
 node_modules/**
+!node_modules/node-notifier/**
+!node_modules/growly/**
+!node_modules/is-wsl/**
+!node_modules/is-docker/**
+!node_modules/semver/**
+!node_modules/shellwords/**
+!node_modules/uuid/**
+!node_modules/which/**
+!node_modules/isexe/**
 src/**
 documents/**
 tsconfig.json
@@ -8,3 +17,8 @@ CONTRIBUTING.md
 images/*.html
 **/*.map
 **/*.ts
+**/test/**
+**/tests/**
+**/example/**
+**/examples/**
+**/.github/**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,18 +2,27 @@
 
 All notable changes to HeyDev will be documented in this file.
 
-## [Unreleased] - V2 in-app redesign
-
-### Changed
-- **In-app notification now uses `vscode.window.withProgress` instead of `showInformationMessage`** (#23). The new mechanism lets HeyDev dismiss the in-app popup programmatically when the mac notification is clicked or the session goes back to working — no more stale popups.
-- The in-app notification shows a single Cancel button (VS Code does not allow renaming it). Cancel acts as "Focus Terminal" — it brings the target terminal into focus.
+## [0.5.0] - 2026-05-12
 
 ### Added
-- New command `HeyDev: Quick Reply to Waiting Session` (`heydev.quickReply`). Moved from the in-app notification's secondary action. If multiple sessions are waiting, a quick picker selects one. Available in command palette and bindable via keyboard shortcut.
-- New command `HeyDev: Open Settings` (`heydev.openSettings`). Opens VS Code settings filtered to HeyDev. Closes #21.
+- **macOS notification escalation** ships as a full feature. When the in-app notification is not interacted with, HeyDev fires a native macOS notification after a configurable delay. Clicking the macOS notification foregrounds VS Code and focuses the originating session terminal — useful for users running multiple VS Code windows.
+- **In-app notification now has inline Focus Terminal and Quick Reply links** that are real clickable commands. The pattern uses `withProgress` with `command:` URI markdown links, giving programmatic dismissal (the macOS notification click cleanly dismisses the in-app popup) while preserving multiple actions.
+- New command `HeyDev: Focus Waiting Session Terminal` (`heydev.focusSession`). Picks a waiting session and focuses its terminal.
+- New command `HeyDev: Quick Reply to Waiting Session` (`heydev.quickReply`). Opens an input box for the user to send a quick reply to a waiting session. Works from the command palette and from the in-app notification link.
+- New command `HeyDev: Open Settings` (`heydev.openSettings`) — closes #21.
+- New configuration: `heydev.enableMacNotifications`, `heydev.macNotificationDelaySeconds`, `heydev.macNotificationSound`.
+- Diagnostic logging in the HeyDev Output Channel covering the full notification lifecycle (state arrivals, in-app scheduled/firing/suppressed/dismissed, mac scheduled/fired/click).
 
-### Known UX notes
-- The single Cancel button on the in-app notification is the only built-in label available — it semantically performs the Focus Terminal action despite saying "Cancel." Tracked as a follow-up to either restyle via a different mechanism (status bar item, webview) or accept as-is.
+### Changed
+- macOS notification timeout extended to 180 seconds so the user has time to click before terminal-notifier auto-dismisses.
+- The in-app notification migrated from `showInformationMessage` to `withProgress` to gain programmatic dismissal.
+
+### Fixed
+- macOS notification reliability — fired via direct `child_process.spawn` with `detached: true` so terminal-notifier escapes the extension host's process group (the default node-notifier spawn was being suppressed on macOS by hardened-runtime entitlements).
+- Notifications could be incorrectly suppressed across waiting cycles — removed a redundant `alreadyNotified.add` in the active-terminal listener that was being re-triggered by macOS Space restoration.
+
+### Known issues
+- macOS notification icon shows Terminal.app icon instead of HeyDev's icon. The bundled terminal-notifier's `-appIcon` flag relies on a private macOS method that is silently ignored on recent macOS versions. Tracked as a follow-up — likely requires forking terminal-notifier with HeyDev's icon baked into the bundle.
 
 ## [0.4.4] - 2026-05-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to HeyDev will be documented in this file.
 
+## [Unreleased] - V2 in-app redesign
+
+### Changed
+- **In-app notification now uses `vscode.window.withProgress` instead of `showInformationMessage`** (#23). The new mechanism lets HeyDev dismiss the in-app popup programmatically when the mac notification is clicked or the session goes back to working — no more stale popups.
+- The in-app notification shows a single Cancel button (VS Code does not allow renaming it). Cancel acts as "Focus Terminal" — it brings the target terminal into focus.
+
+### Added
+- New command `HeyDev: Quick Reply to Waiting Session` (`heydev.quickReply`). Moved from the in-app notification's secondary action. If multiple sessions are waiting, a quick picker selects one. Available in command palette and bindable via keyboard shortcut.
+- New command `HeyDev: Open Settings` (`heydev.openSettings`). Opens VS Code settings filtered to HeyDev. Closes #21.
+
+### Known UX notes
+- The single Cancel button on the in-app notification is the only built-in label available — it semantically performs the Focus Terminal action despite saying "Cancel." Tracked as a follow-up to either restyle via a different mechanism (status bar item, webview) or accept as-is.
+
 ## [0.4.4] - 2026-05-12
 
 ### Fixed
@@ -12,7 +25,7 @@ All notable changes to HeyDev will be documented in this file.
 - Click detection handles `@CONTENTCLICKED` and `@ACTIONCLICKED` (terminal-notifier on macOS 15 emits the latter for body clicks).
 
 ### Known issues
-- The in-app `showInformationMessage` popup stays visible as a stale visual after the mac notification is clicked. VS Code does not expose programmatic per-notification dismissal. Future work: redesign the in-app UX.
+- The in-app `showInformationMessage` popup stays visible as a stale visual after the mac notification is clicked. VS Code does not expose programmatic per-notification dismissal. Future work: redesign the in-app UX. **(Fixed in unreleased V2 above.)**
 
 ## [0.4.3] - 2026-05-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,39 @@
 
 All notable changes to HeyDev will be documented in this file.
 
+## [0.4.4] - 2026-05-12
+
+### Fixed
+- macOS notification not appearing despite the extension's fire path completing successfully. node-notifier's default spawn keeps terminal-notifier attached to the extension host's process group, and VS Code's hardened-runtime extension host appears to suppress notification UI from attached children. Switched to direct `child_process.spawn` with `detached: true` so terminal-notifier runs in its own process group.
+
+## [0.4.3] - 2026-05-12
+
+### Added
+- Aggressive tracing of `alreadyNotified` set mutations for debugging notification flow.
+
+## [0.4.2] - 2026-05-12
+
+### Fixed
+- Notifications could be incorrectly suppressed across waiting cycles. The `onDidChangeActiveTerminal` listener used to add the session to `alreadyNotified`, but macOS Space restoration re-fires this event when returning to VS Code, blocking the next legitimate notification cycle. Removed the redundant flag set — the existing `activeTerminal` guard at fire time still handles the "user is currently looking at the terminal" case.
+
+### Added
+- Logging for terminal focus events in the HeyDev Output Channel.
+
+## [0.4.1] - 2026-05-12
+
+### Added
+- Diagnostic logging in the HeyDev Output Channel for the full notification lifecycle: state arrivals, in-app scheduled/firing/suppressed/skipped, mac scheduled/fired/cancelled/click. Makes debugging notification behavior easy.
+
+## [0.4.0] - 2026-05-12
+
+### Added
+- **macOS notification escalation** — if the in-app notification is not interacted with within a configurable delay, HeyDev now fires a native macOS notification. Clicking the notification focuses the originating VS Code window so you land on the correct workspace, even when running multiple VS Code instances.
+- New configuration settings:
+  - `heydev.enableMacNotifications` (default `true`) — toggle macOS escalation
+  - `heydev.macNotificationDelaySeconds` (default `30`) — seconds to wait after the in-app notification before escalating
+  - `heydev.macNotificationSound` (default `false`) — play sound when the macOS notification fires
+- `node-notifier` runtime dependency — bundles `terminal-notifier.app`, no system install required.
+
 ## [0.3.4] - 2026-04-20
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ All notable changes to HeyDev will be documented in this file.
 ### Fixed
 - macOS notification not appearing despite the extension's fire path completing successfully. node-notifier's default spawn keeps terminal-notifier attached to the extension host's process group, and VS Code's hardened-runtime extension host appears to suppress notification UI from attached children. Switched to direct `child_process.spawn` with `detached: true` so terminal-notifier runs in its own process group.
 
+### Added
+- Mac notification click now both foregrounds VS Code and calls `terminal.show()` on the target session — equivalent to clicking the in-app "Focus Terminal" button.
+- Click detection handles `@CONTENTCLICKED` and `@ACTIONCLICKED` (terminal-notifier on macOS 15 emits the latter for body clicks).
+
+### Known issues
+- The in-app `showInformationMessage` popup stays visible as a stale visual after the mac notification is clicked. VS Code does not expose programmatic per-notification dismissal. Future work: redesign the in-app UX.
+
 ## [0.4.3] - 2026-05-12
 
 ### Added

--- a/docs/superpowers/specs/2026-05-02-mac-notification-escalation-design.md
+++ b/docs/superpowers/specs/2026-05-02-mac-notification-escalation-design.md
@@ -267,6 +267,7 @@ unzip -l heydev-X.Y.Z.vsix | grep node-notifier/vendor
 - **Click-to-focus verification:** Initial implementation detected only `@CONTENTCLICKED`. terminal-notifier on macOS 15 emits `@ACTIONCLICKED` when the body is clicked. Detection now handles both.
 - **Cross-platform escalation:** Windows and Linux escalation deferred to v2.
 - **Smart focus detection (originally proposed Plan D):** detect whether the VS Code app is foregrounded. If not focused, skip in-app and go straight to mac notif. Deferred to v2 once base flow is stable.
+- **Lingering in-app popup after mac click:** When the user clicks the mac notification, we foreground VS Code and call `terminal.show()`. But the awaiting `showInformationMessage` popup stays visible as a stale visual — VS Code does not expose programmatic dismissal of a specific notification. Attempted workaround (`notifications.focusFirstToast` + `notifications.acceptPrimaryAction`) did not reliably dismiss it in testing. Acceptable v1 UX: user can dismiss the stale popup manually via X or its "Focus Terminal" button (which is a no-op since the terminal is already focused). Future work: redesign the in-app UX using a mechanism we fully control (status bar item, `withProgress` with cancel token, or webview).
 
 ## Changelog entry
 

--- a/docs/superpowers/specs/2026-05-02-mac-notification-escalation-design.md
+++ b/docs/superpowers/specs/2026-05-02-mac-notification-escalation-design.md
@@ -1,0 +1,279 @@
+# macOS Notification Escalation — Design Spec
+
+**Date:** 2026-05-02
+**Author:** Salil Monga
+**Status:** Approved (pending implementation)
+
+## Problem
+
+HeyDev currently fires an in-app `showInformationMessage` notification when an AI CLI session enters the `waiting` state. The user runs multiple VS Code windows. If the waiting session is in window A and the user is currently focused on window B, the in-app popup appears only on window A and is easily missed.
+
+## Goal
+
+Escalate to a native macOS notification when the in-app popup is not interacted with within a configurable delay. Clicking the macOS notification should focus the specific VS Code window that originated the notification, so the user lands on the correct workspace.
+
+## Scope
+
+- macOS only (v1). Windows and Linux are out of scope; can be added later via `node-notifier` cross-platform backends.
+- Two-stage escalation: in-app first (existing), then macOS notification.
+- Click on macOS notification focuses the originating VS Code window only. No auto-action (no auto Focus Terminal, no auto Quick Reply).
+- Cross-Space focus is acceptable. macOS will switch Spaces if needed; that matches user intent.
+
+### Out of scope (deferred to v2+)
+
+- Detecting whether the entire VS Code app is in foreground vs background. Future iteration: skip in-app entirely if VS Code app is not focused.
+- Click → auto Focus Terminal or re-show in-app popup. Future iteration once base flow is stable.
+- Cross-platform support (Windows toast, Linux libnotify).
+- Custom branding via forked terminal-notifier binary.
+
+## High-level flow
+
+```
+state="waiting" arrives
+    ↓
+schedule in-app timer (existing, default 60s)
+    ↓
+in-app timer fires → showInformationMessage()
+    ↓
+schedule mac escalation timer (NEW, default 30s)
+    ↓
+mac timer fires → check guards → fire node-notifier
+    ↓
+user clicks → run `open -a "<appName>" <workspacePath>` to focus window
+```
+
+## Architecture
+
+### Approach
+
+Extend the existing `NotificationManager` class directly. Reasoning: notification escalation is notification logic. The class already tracks per-session `pendingTimers`, `activeNotifications`, and `alreadyNotified`. Splitting into a separate class would force shared mutable state across two classes and duplicate the terminal-focus and terminal-closed listeners.
+
+### Files touched
+
+- `src/notificationManager.ts` — extended with mac escalation logic.
+- `package.json` — add `node-notifier` runtime dep, add three configuration settings.
+- `images/icon.png` — reused as macOS notification icon (no new asset needed).
+- `.vscodeignore` — verify `node_modules/node-notifier/vendor/` is included in `.vsix` packaging.
+
+### New dependency
+
+```json
+"dependencies": {
+  "node-notifier": "^10.0.1"
+}
+```
+
+`node-notifier` bundles `terminal-notifier.app` in its `vendor/` directory. No system install required (e.g. no `brew install terminal-notifier` step).
+
+### New state in NotificationManager
+
+```typescript
+private pendingMacTimers = new Map<string, NodeJS.Timeout>();
+private activeMacNotifGroups = new Map<string, string>(); // sessionId -> groupId
+```
+
+## Behavior
+
+### Cancellation matrix
+
+| Event | Cancel pending mac timer? | Dismiss active mac notif? | Clear `alreadyNotified`? |
+|---|---|---|---|
+| State → `working` | Yes | Yes | Yes |
+| Terminal closed | Yes | Yes | Yes |
+| User clicks in-app "Focus Terminal" | Yes | Yes | Keep (mark notified) |
+| User clicks in-app "Quick Reply" | Yes | Yes | Keep |
+| User dismisses in-app via X | Yes | Yes | Keep — no escalation after explicit dismiss |
+| User focuses terminal manually | Yes | Yes | Keep |
+| User clicks mac notif | n/a | Mark consumed | Keep |
+| Mac notif times out | n/a | Clear handle | Keep |
+
+Dismissing the in-app popup via X is treated as "user saw it and made a choice." We do not pester with mac notif after explicit dismissal.
+
+### Re-notification gating
+
+Same as existing logic: once `alreadyNotified` is set for a session, no further notifications fire (in-app or mac) until the session cycles back through `working`. Identical to current `alreadyNotified` semantics.
+
+### Multiple waiting sessions
+
+Each session gets independent timers and an independent macOS notification with a unique `group` ID equal to the session ID. This prevents collisions and allows targeted dismissal via `terminal-notifier -remove <groupId>`.
+
+### Click handler scoping
+
+`notifier.on("click", ...)` is a global event emitter and would fire for any notification when multiple are active. Use the per-call `notifier.notify(opts, callback)` form instead, which passes metadata for the specific notification. The callback closes over `sessionId` and `workspacePath` so each notification routes to the correct session.
+
+### Click action
+
+```typescript
+private focusVSCodeWindow(workspacePath: string | undefined): void {
+  const appName = vscode.env.appName; // "Visual Studio Code", "Cursor", etc.
+  if (workspacePath) {
+    cp.execFile("open", ["-a", appName, workspacePath]);
+  } else {
+    cp.execFile("open", ["-a", appName]);
+  }
+}
+```
+
+`open -a` was chosen over the `code` CLI because:
+- VS Code app is guaranteed installed (the extension is running inside it).
+- `code` CLI is a separate install step (`Shell Command: Install 'code' command in PATH`) that many users skip.
+- macOS Launch Services dedupes by workspace path and focuses the existing window with that workspace open. No new window is created.
+- `vscode.env.appName` handles the Cursor / VS Code Insiders variants automatically.
+
+If testing reveals focus issues (some VS Code GitHub issues report `code` CLI does not always transfer focus), chain with osascript activate as a belt-and-suspenders fallback:
+
+```typescript
+cp.execFile("open", ["-a", appName, workspacePath], () => {
+  cp.execFile("osascript", ["-e", `tell application "${appName}" to activate`]);
+});
+```
+
+### Workspace path capture
+
+Capture the workspace path at notification schedule time, not at click time, because the workspace can change before the user clicks.
+
+```typescript
+private getWorkspacePath(): string | undefined {
+  const wsFile = vscode.workspace.workspaceFile;
+  if (wsFile && wsFile.scheme === "file") return wsFile.fsPath;
+  const folders = vscode.workspace.workspaceFolders;
+  if (folders && folders.length > 0) return folders[0].uri.fsPath;
+  return undefined;
+}
+```
+
+If no workspace is open (rare for terminal users), fall back to plain app activation.
+
+### Platform guard
+
+```typescript
+if (process.platform !== "darwin") return;
+```
+
+Skip mac escalation entirely on Windows and Linux. Document in README.
+
+### Critical finding during implementation: detached spawn required
+
+During testing we discovered that `notifier.notify()` from node-notifier silently fails to display notifications when called from inside the VS Code extension host, even though the same call works from a regular `node` process. Cause: node-notifier's default `child_process.spawn` keeps the spawned terminal-notifier in the extension host's process group, and VS Code's hardened-runtime extension host appears to suppress notification UI from attached child processes.
+
+Fix: bypass `notifier.notify()` and spawn the bundled terminal-notifier binary directly with `child_process.spawn(path, args, { detached: true, stdio: ["ignore", "pipe", "pipe"] })` followed by `child.unref()`. This puts terminal-notifier in its own process group, decoupled from the extension host.
+
+We still read stdout to detect clicks. terminal-notifier emits `@CONTENTCLICKED`, `@ACTIONCLICKED`, `@TIMEOUT`, or `@CLOSED`. Both click variants trigger the focus-window flow.
+
+### node-notifier invocation (legacy reference)
+
+```typescript
+notifier.notify({
+  title: `[${state.tag}] waiting`,
+  message: snippet || "AI session needs your attention",
+  icon: path.join(extensionPath, "images", "icon.png"),
+  sound: config.get<boolean>("macNotificationSound", false),
+  wait: true,
+  timeout: 30,
+  group: state.session_id,
+}, callback);
+```
+
+The `icon` option maps to `terminal-notifier`'s `-appIcon` flag, which uses a private macOS API to display a custom icon in the notification. This is documented as "subject to change" by terminal-notifier upstream but works reliably on macOS 13, 14, and 15. If Apple breaks it in a future release, fall back to default icon (functional impact zero).
+
+The `-sender` flag is intentionally NOT used. `-sender` displays the spoofed app's icon but breaks the click callback because terminal-notifier delegates click handling to the spoofed app's launch.
+
+## Configuration
+
+New `package.json` settings:
+
+```json
+"heydev.enableMacNotifications": {
+  "type": "boolean",
+  "default": true,
+  "description": "Escalate to a native macOS notification if the in-app notification is not interacted with. macOS only."
+},
+"heydev.macNotificationDelaySeconds": {
+  "type": "number",
+  "default": 30,
+  "minimum": 5,
+  "maximum": 600,
+  "description": "Seconds to wait after the in-app notification before showing a macOS notification."
+},
+"heydev.macNotificationSound": {
+  "type": "boolean",
+  "default": false,
+  "description": "Play sound when the macOS notification fires."
+}
+```
+
+### Master switch behavior
+
+| `showNotifications` | `enableMacNotifications` | Result |
+|---|---|---|
+| false | any | No notifications at all |
+| true | false | In-app only (current behavior) |
+| true | true | In-app + mac escalation |
+
+### Config read timing
+
+Read configuration at fire time via `vscode.workspace.getConfiguration("heydev")`, not in the constructor. This matches the existing pattern in `scheduleNotification` and lets users change configuration without reloading the window.
+
+## Logging
+
+Add to existing Output Channel:
+
+- `[mac-notif] scheduled for session X in 30s`
+- `[mac-notif] fired for session X`
+- `[mac-notif] cancelled for session X (reason)`
+- `[mac-notif] click handler invoked, focusing window at <path>`
+- `[mac-notif] node-notifier error: <msg>`
+
+## Failure modes
+
+| Failure | Behavior |
+|---|---|
+| `node-notifier` vendor binary missing (bad packaging) | Log error, fall through silently. In-app still works. |
+| User has disabled HeyDev / VS Code in System Settings → Notifications | OS suppresses silently. No-op. Document in README troubleshooting. |
+| macOS Focus / Do Not Disturb mode active | OS suppresses. Expected. |
+| Extension reload while notif active | Subprocess survives reload. Click callback dies. User click does nothing. Acceptable degradation. |
+
+Optional polish (not required for v1): on extension activation, fire `terminal-notifier -remove ALL` on our group prefix to clean up orphans from a previous session.
+
+## Test plan
+
+Manual verification only. Real macOS environment required. The extension cannot reliably unit-test native notifications.
+
+### Required scenarios
+
+1. **Happy path:** 2 VS Code windows. Trigger waiting in A, focus B. Wait > 60s + 30s. Mac notif appears. Click → window A focused with correct workspace.
+2. **In-app interaction cancels mac:** Trigger waiting, stay focused, in-app fires, click "Focus Terminal" within 30s. Mac notif never fires.
+3. **In-app dismiss cancels mac:** In-app fires, click X. Mac notif never fires.
+4. **State change cancels mac:** In-app fires, AI returns to working before 30s. Mac timer cancelled.
+5. **Multiple sessions:** Two AI CLIs both in waiting. Two distinct mac notifs, each click focuses correct window.
+6. **Click missed:** Mac notif fires, ignore for 30s. Auto-dismisses, state cleaned.
+7. **Re-notification gating:** Mac notif fires, dismiss. Same session stays waiting. No re-notify. Session cycles to working → waiting again. Re-notify allowed.
+8. **Config off:** `enableMacNotifications: false`. Only in-app fires.
+9. **Platform guard:** Windows / Linux: only in-app. macOS: both.
+10. **Icon verification:** Mac notif shows HeyDev icon, not Terminal icon.
+
+### Packaging verification
+
+```bash
+vsce package
+unzip -l heydev-X.Y.Z.vsix | grep node-notifier/vendor
+# Expect terminal-notifier.app entries present
+```
+
+## Known limitations / follow-ups
+
+- **Existing in-app "Focus Terminal" bug:** User reports the existing in-app popup's "Focus Terminal" button works inconsistently. Tracked as a follow-up task. Out of scope for this spec.
+- **`-appIcon` ignored on macOS 15+:** During testing the bundled `terminal-notifier` did not honor the `-appIcon` flag — the notification displays the default Terminal.app icon regardless. The `-appIcon` flag relies on a private macOS method that recent macOS versions appear to ignore. Future work: fork terminal-notifier and rebake the .app bundle with HeyDev's icon as the bundle icon, OR investigate alternative notification mechanisms (native UNUserNotificationCenter via a tiny signed helper binary).
+- **Click-to-focus verification:** Initial implementation detected only `@CONTENTCLICKED`. terminal-notifier on macOS 15 emits `@ACTIONCLICKED` when the body is clicked. Detection now handles both.
+- **Cross-platform escalation:** Windows and Linux escalation deferred to v2.
+- **Smart focus detection (originally proposed Plan D):** detect whether the VS Code app is foregrounded. If not focused, skip in-app and go straight to mac notif. Deferred to v2 once base flow is stable.
+
+## Changelog entry
+
+When implemented, add to `CHANGELOG.md`:
+
+```
+### Added
+- macOS notification escalation: if the in-app notification is not interacted with, fire a native macOS notification after a configurable delay. Clicking the notification focuses the originating VS Code window.
+- Configuration: `heydev.enableMacNotifications`, `heydev.macNotificationDelaySeconds`, `heydev.macNotificationSound`.
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,19 @@
 {
-  "name": "claude-terminal-status",
-  "version": "0.1.0",
+  "name": "heydev",
+  "version": "0.3.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "claude-terminal-status",
-      "version": "0.1.0",
+      "name": "heydev",
+      "version": "0.3.5",
+      "license": "MIT",
+      "dependencies": {
+        "node-notifier": "^10.0.1"
+      },
       "devDependencies": {
         "@types/node": "^20.0.0",
+        "@types/node-notifier": "^8.0.5",
         "@types/vscode": "^1.85.0",
         "@vscode/vsce": "^3.0.0",
         "typescript": "^5.5.0"
@@ -555,6 +560,16 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/node-notifier": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/@types/node-notifier/-/node-notifier-8.0.5.tgz",
+      "integrity": "sha512-LX7+8MtTsv6szumAp6WOy87nqMEdGhhry/Qfprjm1Ma6REjVzeF7SCyvPtp5RaF6IkXCS9V4ra8g5fwvf2ZAYg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/normalize-package-data": {
@@ -1887,6 +1902,12 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/growly": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
+      "integrity": "sha512-+xGQY0YyAWCnqy7Cd++hc2JqMYzlm0dG30Jd0beaA64sROr8C4nt8Yc9V5Ro3avlSUDTN0ulqP/VBKi1/lLygw==",
+      "license": "MIT"
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -2185,7 +2206,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/istextorbinary": {
@@ -2631,6 +2651,47 @@
       "dev": true,
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/node-notifier": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-10.0.1.tgz",
+      "integrity": "sha512-YX7TSyDukOZ0g+gmzjB6abKu+hTGvO8+8+gIFDsRCU2t8fLV/P2unmt+LGFaIa4y64aX98Qksa97rgz4vMNeLQ==",
+      "license": "MIT",
+      "dependencies": {
+        "growly": "^1.3.0",
+        "is-wsl": "^2.2.0",
+        "semver": "^7.3.5",
+        "shellwords": "^0.1.1",
+        "uuid": "^8.3.2",
+        "which": "^2.0.2"
+      }
+    },
+    "node_modules/node-notifier/node_modules/is-docker": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/node-notifier/node_modules/is-wsl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/node-sarif-builder": {
       "version": "3.4.0",
@@ -3237,7 +3298,6 @@
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -3268,6 +3328,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/shellwords": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
+      "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
+      "license": "MIT"
     },
     "node_modules/side-channel": {
       "version": "1.1.0",
@@ -3868,7 +3934,6 @@
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
@@ -3926,7 +3991,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -47,6 +47,14 @@
       {
         "command": "heydev.removeHooks",
         "title": "HeyDev: Remove All Hooks (Claude, Codex)"
+      },
+      {
+        "command": "heydev.openSettings",
+        "title": "HeyDev: Open Settings"
+      },
+      {
+        "command": "heydev.quickReply",
+        "title": "HeyDev: Quick Reply to Waiting Session"
       }
     ],
     "configuration": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "heydev",
   "displayName": "HeyDev",
   "description": "Real-time status indicators for AI CLI sessions (Claude Code, Codex, Copilot) in VS Code terminal tabs, with smart notifications and quick reply",
-  "version": "0.3.5",
+  "version": "0.4.4",
   "publisher": "salilmonga",
   "license": "MIT",
   "repository": {
@@ -31,8 +31,12 @@
     "vscode": "^1.85.0"
   },
   "icon": "images/icon.png",
-  "categories": ["Other"],
-  "activationEvents": ["onStartupFinished"],
+  "categories": [
+    "Other"
+  ],
+  "activationEvents": [
+    "onStartupFinished"
+  ],
   "main": "./out/extension.js",
   "contributes": {
     "commands": [
@@ -73,6 +77,23 @@
           "type": "string",
           "default": "",
           "description": "Override state file directory (default: ~/.heydev/state)"
+        },
+        "heydev.enableMacNotifications": {
+          "type": "boolean",
+          "default": true,
+          "description": "Escalate to a native macOS notification if the in-app notification is not interacted with. macOS only."
+        },
+        "heydev.macNotificationDelaySeconds": {
+          "type": "number",
+          "default": 30,
+          "minimum": 5,
+          "maximum": 600,
+          "description": "Seconds to wait after the in-app notification before showing a macOS notification."
+        },
+        "heydev.macNotificationSound": {
+          "type": "boolean",
+          "default": false,
+          "description": "Play sound when the macOS notification fires."
         }
       }
     },
@@ -142,8 +163,12 @@
     "watch": "tsc -watch -p ./",
     "package": "vsce package"
   },
+  "dependencies": {
+    "node-notifier": "^10.0.1"
+  },
   "devDependencies": {
     "@types/node": "^20.0.0",
+    "@types/node-notifier": "^8.0.5",
     "@types/vscode": "^1.85.0",
     "@vscode/vsce": "^3.0.0",
     "typescript": "^5.5.0"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "heydev",
   "displayName": "HeyDev",
   "description": "Real-time status indicators for AI CLI sessions (Claude Code, Codex, Copilot) in VS Code terminal tabs, with smart notifications and quick reply",
-  "version": "0.4.4",
+  "version": "0.5.0",
   "publisher": "salilmonga",
   "license": "MIT",
   "repository": {
@@ -51,6 +51,10 @@
       {
         "command": "heydev.openSettings",
         "title": "HeyDev: Open Settings"
+      },
+      {
+        "command": "heydev.focusSession",
+        "title": "HeyDev: Focus Waiting Session Terminal"
       },
       {
         "command": "heydev.quickReply",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -32,7 +32,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 
   const watcher = new SessionWatcher(stateDir);
   const terminalMgr = new TerminalManager();
-  const notificationMgr = new NotificationManager(terminalMgr);
+  const notificationMgr = new NotificationManager(terminalMgr, context.extensionPath);
 
   // Register commands
   const extPath = context.extensionPath;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -38,7 +38,31 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
   const extPath = context.extensionPath;
   context.subscriptions.push(
     vscode.commands.registerCommand("heydev.setup", () => runSetup(extPath)),
-    vscode.commands.registerCommand("heydev.removeHooks", runUninstall)
+    vscode.commands.registerCommand("heydev.removeHooks", runUninstall),
+    vscode.commands.registerCommand("heydev.openSettings", () =>
+      vscode.commands.executeCommand("workbench.action.openSettings", "heydev")
+    ),
+    vscode.commands.registerCommand("heydev.quickReply", async () => {
+      const waiting = notificationMgr.getWaitingSessions();
+      if (waiting.length === 0) {
+        vscode.window.showInformationMessage("No AI CLI sessions are currently waiting.");
+        return;
+      }
+      let target = waiting[0];
+      if (waiting.length > 1) {
+        const pick = await vscode.window.showQuickPick(
+          waiting.map((s) => ({
+            label: `[${s.tag}]`,
+            description: s.last_message?.slice(0, 80) ?? "",
+            session: s,
+          })),
+          { placeHolder: "Pick a waiting AI CLI session" }
+        );
+        if (!pick) return;
+        target = pick.session;
+      }
+      await notificationMgr.sendQuickReply(target.session_id);
+    })
   );
 
   // Clean up stale state files on startup (older than 5 minutes)

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -42,7 +42,34 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     vscode.commands.registerCommand("heydev.openSettings", () =>
       vscode.commands.executeCommand("workbench.action.openSettings", "heydev")
     ),
-    vscode.commands.registerCommand("heydev.quickReply", async () => {
+    vscode.commands.registerCommand("heydev.focusSession", (sessionId?: string) => {
+      if (sessionId) {
+        notificationMgr.focusSession(sessionId);
+        return;
+      }
+      // No sessionId arg → resolve via waiting list (palette path)
+      const waiting = notificationMgr.getWaitingSessions();
+      if (waiting.length === 0) {
+        vscode.window.showInformationMessage("No AI CLI sessions are currently waiting.");
+        return;
+      }
+      if (waiting.length === 1) {
+        notificationMgr.focusSession(waiting[0].session_id);
+      } else {
+        vscode.window.showQuickPick(
+          waiting.map((s) => ({ label: `[${s.tag}]`, description: s.last_message?.slice(0, 80) ?? "", session: s })),
+          { placeHolder: "Pick a waiting AI CLI session to focus" }
+        ).then((pick) => {
+          if (pick) notificationMgr.focusSession(pick.session.session_id);
+        });
+      }
+    }),
+    vscode.commands.registerCommand("heydev.quickReply", async (sessionId?: string) => {
+      if (sessionId) {
+        await notificationMgr.sendQuickReply(sessionId);
+        return;
+      }
+      // No sessionId arg → resolve via waiting list (palette path)
       const waiting = notificationMgr.getWaitingSessions();
       if (waiting.length === 0) {
         vscode.window.showInformationMessage("No AI CLI sessions are currently waiting.");

--- a/src/notificationManager.ts
+++ b/src/notificationManager.ts
@@ -1,40 +1,75 @@
 import * as vscode from "vscode";
+import * as path from "path";
+import * as cp from "child_process";
+import * as notifier from "node-notifier";
 import type { SessionState } from "./types.js";
 import type { TerminalManager } from "./terminalManager.js";
 
 export class NotificationManager {
   private terminalManager: TerminalManager;
-  // Pending notification timers per session — cancelled if state changes or terminal focused
+  private extensionPath: string;
+  private outputChannel: vscode.OutputChannel;
+  // Pending in-app notification timers per session — cancelled if state changes or terminal focused
   private pendingTimers = new Map<string, NodeJS.Timeout>();
-  // Track which sessions have a visible notification so we can ignore stale clicks
+  // Pending mac escalation timers per session — scheduled after in-app fires
+  private pendingMacTimers = new Map<string, NodeJS.Timeout>();
+  // Active mac notification group IDs (for programmatic dismissal via terminal-notifier -remove)
+  private activeMacNotifGroups = new Map<string, string>();
+  // Track which sessions have a visible in-app notification so we can ignore stale clicks
   private activeNotifications = new Set<string>();
   // Track sessions that have already been notified — don't re-notify until state cycles back through "working"
-  private alreadyNotified = new Set<string>();
+  private _alreadyNotified = new Set<string>();
   private disposables: vscode.Disposable[] = [];
 
-  constructor(terminalManager: TerminalManager) {
+  // Traced accessors for alreadyNotified — log every add/delete so we can see exactly when state changes.
+  private alreadyNotifiedAdd(sessionId: string, source: string): void {
+    this._alreadyNotified.add(sessionId);
+    this.outputChannel.appendLine(
+      `[alreadyNotified] +ADD session ${sessionId} (by ${source}) — set size: ${this._alreadyNotified.size}`
+    );
+  }
+  private alreadyNotifiedDelete(sessionId: string, source: string): void {
+    const had = this._alreadyNotified.has(sessionId);
+    this._alreadyNotified.delete(sessionId);
+    this.outputChannel.appendLine(
+      `[alreadyNotified] -DEL session ${sessionId} (by ${source}) — had=${had} set size: ${this._alreadyNotified.size}`
+    );
+  }
+  private get alreadyNotified() {
+    return {
+      has: (id: string) => this._alreadyNotified.has(id),
+      // Compatibility stubs — should never be called directly; use traced helpers
+      add: (id: string) => this.alreadyNotifiedAdd(id, "direct"),
+      delete: (id: string) => this.alreadyNotifiedDelete(id, "direct"),
+      clear: () => this._alreadyNotified.clear(),
+    };
+  }
+
+  constructor(terminalManager: TerminalManager, extensionPath: string) {
     this.terminalManager = terminalManager;
+    this.extensionPath = extensionPath;
+    this.outputChannel = vscode.window.createOutputChannel("HeyDev");
   }
 
   start(): void {
     // Cancel everything when a terminal is closed
     this.terminalManager.onTerminalClosed((sessionId) => {
-      this.cancelPending(sessionId);
-      this.activeNotifications.delete(sessionId);
-      this.alreadyNotified.delete(sessionId);
+      this.cancelAll(sessionId, "terminal closed");
+      this.alreadyNotifiedDelete(sessionId, "terminal closed");
     });
 
-    // Cancel pending notifications when user manually switches to a Claude terminal
+    // Cancel pending notifications when user manually switches to a Claude terminal.
+    // Note: we do NOT add to alreadyNotified here — that would persist across waiting
+    // cycles. The activeTerminal guard in showNotification handles "currently looking."
     this.disposables.push(
       vscode.window.onDidChangeActiveTerminal((terminal) => {
         if (!terminal) return;
-        // Find which session this terminal belongs to
         for (const [sessionId, tracked] of this.terminalManager.getAllSessions()) {
           if (tracked.terminal === terminal) {
-            this.cancelPending(sessionId);
-            // Mark notification as stale so clicks are ignored, and prevent re-notify
-            this.activeNotifications.delete(sessionId);
-            this.alreadyNotified.add(sessionId);
+            this.outputChannel.appendLine(
+              `[focus] terminal for session ${sessionId} became active — cancelling pending`
+            );
+            this.cancelAll(sessionId, "terminal focused");
             break;
           }
         }
@@ -44,31 +79,57 @@ export class NotificationManager {
 
   /** Called on every state change. Schedules or cancels notifications. */
   handleStateChange(state: SessionState): void {
+    this.outputChannel.appendLine(
+      `[state] session ${state.session_id} -> ${state.state} (tag=${state.tag})`
+    );
     if (state.state === "waiting") {
       this.scheduleNotification(state);
     } else {
-      // State changed to "working" — cancel any pending notification and reset notified flag
-      this.cancelPending(state.session_id);
-      this.activeNotifications.delete(state.session_id);
-      this.alreadyNotified.delete(state.session_id);
+      // State changed to "working" — cancel pending in-app + mac, dismiss active mac, reset notified flag
+      this.cancelAll(state.session_id, "state -> working");
+      this.alreadyNotifiedDelete(state.session_id, "state -> working");
     }
   }
 
   private scheduleNotification(state: SessionState): void {
     const config = vscode.workspace.getConfiguration("heydev");
-    if (!config.get<boolean>("showNotifications", true)) return;
+    if (!config.get<boolean>("showNotifications", true)) {
+      this.outputChannel.appendLine(
+        `[in-app] skipped for session ${state.session_id} (showNotifications=false)`
+      );
+      return;
+    }
 
     // Only notify for sessions that belong to a terminal in THIS VS Code instance
-    if (!this.terminalManager.getTerminalForSession(state.session_id)) return;
+    if (!this.terminalManager.getTerminalForSession(state.session_id)) {
+      this.outputChannel.appendLine(
+        `[in-app] skipped for session ${state.session_id} (terminal not tracked in this window)`
+      );
+      return;
+    }
 
     // Don't re-notify if we already sent one for this waiting period
-    if (this.alreadyNotified.has(state.session_id)) return;
+    if (this.alreadyNotified.has(state.session_id)) {
+      this.outputChannel.appendLine(
+        `[in-app] skipped for session ${state.session_id} (alreadyNotified)`
+      );
+      return;
+    }
 
     // Don't schedule if there's already a pending timer
-    if (this.pendingTimers.has(state.session_id)) return;
+    if (this.pendingTimers.has(state.session_id)) {
+      this.outputChannel.appendLine(
+        `[in-app] skipped for session ${state.session_id} (timer already pending)`
+      );
+      return;
+    }
 
     const delaySeconds = config.get<number>("notificationDelaySeconds", 60);
     const delayMs = delaySeconds * 1000;
+
+    this.outputChannel.appendLine(
+      `[in-app] scheduled for session ${state.session_id} in ${delaySeconds}s`
+    );
 
     const timer = setTimeout(() => {
       this.pendingTimers.delete(state.session_id);
@@ -82,7 +143,16 @@ export class NotificationManager {
     const terminal = this.terminalManager.getTerminalForSession(state.session_id);
 
     // Don't notify if the terminal is already focused
-    if (terminal && vscode.window.activeTerminal === terminal) return;
+    if (terminal && vscode.window.activeTerminal === terminal) {
+      this.outputChannel.appendLine(
+        `[in-app] suppressed for session ${state.session_id} (terminal is active)`
+      );
+      return;
+    }
+
+    this.outputChannel.appendLine(
+      `[in-app] firing for session ${state.session_id}`
+    );
 
     const timeLabel = delaySeconds >= 60
       ? `${Math.round(delaySeconds / 60)} minute${Math.round(delaySeconds / 60) > 1 ? "s" : ""}`
@@ -99,13 +169,19 @@ export class NotificationManager {
 
     // Mark this notification as active and already notified
     this.activeNotifications.add(state.session_id);
-    this.alreadyNotified.add(state.session_id);
+    this.alreadyNotifiedAdd(state.session_id, "showNotification");
+
+    // Schedule mac escalation in parallel with awaiting in-app interaction
+    this.scheduleMacEscalation(state, snippet);
 
     const action = await vscode.window.showInformationMessage(
       message,
       "Focus Terminal",
       "Quick Reply"
     );
+
+    // Any in-app interaction (or dismissal) cancels the mac escalation
+    this.cancelMacEscalation(state.session_id, "in-app interaction");
 
     // If notification was dismissed (user switched to terminal manually), ignore the click
     if (!this.activeNotifications.has(state.session_id)) return;
@@ -126,12 +202,173 @@ export class NotificationManager {
     }
   }
 
-  private cancelPending(sessionId: string): void {
+  private scheduleMacEscalation(state: SessionState, snippet: string): void {
+    if (process.platform !== "darwin") return;
+
+    const config = vscode.workspace.getConfiguration("heydev");
+    if (!config.get<boolean>("enableMacNotifications", true)) return;
+
+    if (this.pendingMacTimers.has(state.session_id)) return;
+
+    const delaySeconds = config.get<number>("macNotificationDelaySeconds", 30);
+    const workspacePath = this.getWorkspacePath();
+    const playSound = config.get<boolean>("macNotificationSound", false);
+
+    this.outputChannel.appendLine(
+      `[mac-notif] scheduled for session ${state.session_id} in ${delaySeconds}s`
+    );
+
+    const timer = setTimeout(() => {
+      this.pendingMacTimers.delete(state.session_id);
+      this.fireMacNotification(state, snippet, workspacePath, playSound);
+    }, delaySeconds * 1000);
+
+    this.pendingMacTimers.set(state.session_id, timer);
+  }
+
+  private fireMacNotification(
+    state: SessionState,
+    snippet: string,
+    workspacePath: string | undefined,
+    playSound: boolean
+  ): void {
+    const terminal = this.terminalManager.getTerminalForSession(state.session_id);
+    // Last-second guard: if terminal got focused while timer was running, skip
+    if (terminal && vscode.window.activeTerminal === terminal) {
+      this.outputChannel.appendLine(
+        `[mac-notif] suppressed for session ${state.session_id} (terminal focused)`
+      );
+      return;
+    }
+
+    const groupId = `heydev-${state.session_id}`;
+    this.activeMacNotifGroups.set(state.session_id, groupId);
+
+    const iconPath = path.join(this.extensionPath, "images", "icon.png");
+    const message = snippet
+      ? snippet.replace(/^: /, "").replace(/^"|"$/g, "")
+      : "AI session needs your attention";
+
+    // Spawn terminal-notifier directly with detached:true so it escapes the extension host's
+    // process group. node-notifier's default spawn keeps the child attached, and VS Code's
+    // hardened-runtime extension host appears to block notification UI from attached children.
+    const terminalNotifierPath = path.join(
+      this.extensionPath,
+      "node_modules",
+      "node-notifier",
+      "vendor",
+      "mac.noindex",
+      "terminal-notifier.app",
+      "Contents",
+      "MacOS",
+      "terminal-notifier"
+    );
+
+    const args = [
+      "-title", `[${state.tag}] waiting`,
+      "-message", message,
+      "-appIcon", iconPath,
+      "-group", groupId,
+      "-timeout", "30",
+    ];
+    if (playSound) args.push("-sound", "default");
+
+    this.outputChannel.appendLine(
+      `[mac-notif] fired for session ${state.session_id} (binary=${terminalNotifierPath})`
+    );
+
+    const child = cp.spawn(terminalNotifierPath, args, {
+      detached: true,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    // Collect stdout for click detection. terminal-notifier emits @CONTENTCLICKED on click,
+    // @TIMEOUT on auto-dismiss, @CLOSED on user dismissal.
+    let stdoutBuf = "";
+    child.stdout?.on("data", (chunk: Buffer) => {
+      stdoutBuf += chunk.toString();
+    });
+    child.on("error", (err) => {
+      this.outputChannel.appendLine(
+        `[mac-notif] spawn error: ${err.message}`
+      );
+      this.activeMacNotifGroups.delete(state.session_id);
+    });
+    child.on("close", (code) => {
+      this.outputChannel.appendLine(
+        `[mac-notif] subprocess exited code=${code} stdout="${stdoutBuf.trim()}"`
+      );
+      // terminal-notifier emits: @CONTENTCLICKED (body click), @ACTIONCLICKED (action button),
+      // @TIMEOUT (auto-dismiss), @CLOSED (manual dismiss). Treat any "click" type as a click.
+      const wasClicked =
+        stdoutBuf.includes("@CONTENTCLICKED") ||
+        stdoutBuf.includes("@ACTIONCLICKED") ||
+        stdoutBuf.includes("activate");
+      if (wasClicked) {
+        this.outputChannel.appendLine(
+          `[mac-notif] click handler invoked, focusing window at ${workspacePath ?? "(no workspace)"}`
+        );
+        this.focusVSCodeWindow(workspacePath);
+      }
+      this.activeMacNotifGroups.delete(state.session_id);
+    });
+    // Detach the child so it can outlive the extension host's process group if needed.
+    child.unref();
+  }
+
+  private cancelMacEscalation(sessionId: string, reason: string): void {
+    const timer = this.pendingMacTimers.get(sessionId);
+    if (timer) {
+      clearTimeout(timer);
+      this.pendingMacTimers.delete(sessionId);
+      this.outputChannel.appendLine(
+        `[mac-notif] cancelled for session ${sessionId} (${reason})`
+      );
+    }
+    const groupId = this.activeMacNotifGroups.get(sessionId);
+    if (groupId) {
+      this.dismissActiveMacNotif(groupId);
+      this.activeMacNotifGroups.delete(sessionId);
+    }
+  }
+
+  private dismissActiveMacNotif(groupId: string): void {
+    if (process.platform !== "darwin") return;
+    // terminal-notifier -remove <group> dismisses the notification by group ID
+    // Cast to any — `remove` is a valid terminal-notifier flag but missing from @types/node-notifier
+    notifier.notify({ remove: groupId } as any, () => {
+      // Ignore errors — best-effort dismissal
+    });
+  }
+
+  private focusVSCodeWindow(workspacePath: string | undefined): void {
+    const appName = vscode.env.appName || "Visual Studio Code";
+    const args = workspacePath ? ["-a", appName, workspacePath] : ["-a", appName];
+    cp.execFile("open", args, (err) => {
+      if (err) {
+        this.outputChannel.appendLine(
+          `[mac-notif] open failed: ${err.message}`
+        );
+      }
+    });
+  }
+
+  private getWorkspacePath(): string | undefined {
+    const wsFile = vscode.workspace.workspaceFile;
+    if (wsFile && wsFile.scheme === "file") return wsFile.fsPath;
+    const folders = vscode.workspace.workspaceFolders;
+    if (folders && folders.length > 0) return folders[0].uri.fsPath;
+    return undefined;
+  }
+
+  private cancelAll(sessionId: string, reason: string): void {
     const timer = this.pendingTimers.get(sessionId);
     if (timer) {
       clearTimeout(timer);
       this.pendingTimers.delete(sessionId);
     }
+    this.cancelMacEscalation(sessionId, reason);
+    this.activeNotifications.delete(sessionId);
   }
 
   dispose(): void {
@@ -139,10 +376,19 @@ export class NotificationManager {
       clearTimeout(timer);
     }
     this.pendingTimers.clear();
+    for (const timer of this.pendingMacTimers.values()) {
+      clearTimeout(timer);
+    }
+    this.pendingMacTimers.clear();
+    for (const groupId of this.activeMacNotifGroups.values()) {
+      this.dismissActiveMacNotif(groupId);
+    }
+    this.activeMacNotifGroups.clear();
     this.activeNotifications.clear();
-    this.alreadyNotified.clear();
+    this._alreadyNotified.clear();
     for (const d of this.disposables) {
       d.dispose();
     }
+    this.outputChannel.dispose();
   }
 }

--- a/src/notificationManager.ts
+++ b/src/notificationManager.ts
@@ -19,6 +19,11 @@ export class NotificationManager {
   private activeNotifications = new Set<string>();
   // Track sessions that have already been notified — don't re-notify until state cycles back through "working"
   private _alreadyNotified = new Set<string>();
+  // Per-session resolver to programmatically dismiss the withProgress in-app notification.
+  // Calling the resolver dismisses the in-app popup naturally via VS Code's own UI.
+  private inAppDismissers = new Map<string, () => void>();
+  // Track currently-waiting sessions so the Quick Reply command can find them.
+  private waitingSessions = new Map<string, SessionState>();
   private disposables: vscode.Disposable[] = [];
 
   // Traced accessors for alreadyNotified — log every add/delete so we can see exactly when state changes.
@@ -170,35 +175,78 @@ export class NotificationManager {
     // Mark this notification as active and already notified
     this.activeNotifications.add(state.session_id);
     this.alreadyNotifiedAdd(state.session_id, "showNotification");
+    this.waitingSessions.set(state.session_id, state);
 
     // Schedule mac escalation in parallel with awaiting in-app interaction
     this.scheduleMacEscalation(state, snippet);
 
-    const action = await vscode.window.showInformationMessage(
-      message,
-      "Focus Terminal",
-      "Quick Reply"
+    // V2 — withProgress instead of showInformationMessage so we can dismiss programmatically.
+    // The promise we return controls the notification lifetime:
+    //   - User clicks Cancel → token.onCancellationRequested → resolve → dismiss
+    //   - Mac click handler calls our stored dismisser → resolve → dismiss
+    //   - state -> working → cancelMacEscalation also calls dismisser → resolve → dismiss
+    // VS Code uses its own Cancel button label, which we cannot rename. We treat Cancel
+    // as the "Focus Terminal" action — a slight UX wart, documented in CHANGELOG and #23.
+    let dismissReason: string = "external";
+    await vscode.window.withProgress(
+      {
+        location: vscode.ProgressLocation.Notification,
+        title: message,
+        cancellable: true,
+      },
+      (_progress, token) => {
+        return new Promise<void>((resolve) => {
+          this.inAppDismissers.set(state.session_id, () => {
+            dismissReason = "external";
+            this.inAppDismissers.delete(state.session_id);
+            resolve();
+          });
+          token.onCancellationRequested(() => {
+            dismissReason = "cancel";
+            this.inAppDismissers.delete(state.session_id);
+            resolve();
+          });
+        });
+      }
     );
 
-    // Any in-app interaction (or dismissal) cancels the mac escalation
-    this.cancelMacEscalation(state.session_id, "in-app interaction");
-
-    // If notification was dismissed (user switched to terminal manually), ignore the click
-    if (!this.activeNotifications.has(state.session_id)) return;
+    // After in-app dismisses for any reason — cancel mac escalation
+    this.cancelMacEscalation(state.session_id, `in-app dismissed (${dismissReason})`);
     this.activeNotifications.delete(state.session_id);
 
-    if (!terminal) return;
+    this.outputChannel.appendLine(
+      `[in-app] dismissed for session ${state.session_id} (${dismissReason})`
+    );
 
-    if (action === "Focus Terminal") {
+    // User-initiated cancel = treat as "Focus Terminal" action
+    if (dismissReason === "cancel" && terminal) {
       terminal.show();
-    } else if (action === "Quick Reply") {
-      const reply = await vscode.window.showInputBox({
-        prompt: `Reply to [${state.tag}]`,
-        placeHolder: "Type your response (e.g. yes, no, continue...)",
-      });
-      if (reply !== undefined && reply.trim() !== "") {
-        terminal.sendText(reply.trim());
-      }
+    }
+  }
+
+  /** Public — called by the heydev.quickReply command. Returns the active waiting sessions. */
+  getWaitingSessions(): SessionState[] {
+    return [...this.waitingSessions.values()];
+  }
+
+  /** Public — send a quick reply to a specific session's terminal. */
+  async sendQuickReply(sessionId: string): Promise<void> {
+    const state = this.waitingSessions.get(sessionId);
+    if (!state) {
+      vscode.window.showWarningMessage(`Session ${sessionId} is no longer waiting.`);
+      return;
+    }
+    const terminal = this.terminalManager.getTerminalForSession(sessionId);
+    if (!terminal) {
+      vscode.window.showWarningMessage(`No tracked terminal for session ${sessionId}.`);
+      return;
+    }
+    const reply = await vscode.window.showInputBox({
+      prompt: `Reply to [${state.tag}]`,
+      placeHolder: "Type your response (e.g. yes, no, continue...)",
+    });
+    if (reply !== undefined && reply.trim() !== "") {
+      terminal.sendText(reply.trim());
     }
   }
 
@@ -269,7 +317,7 @@ export class NotificationManager {
       "-message", message,
       "-appIcon", iconPath,
       "-group", groupId,
-      "-timeout", "30",
+      "-timeout", "60",
     ];
     if (playSound) args.push("-sound", "default");
 
@@ -322,11 +370,14 @@ export class NotificationManager {
             `[mac-notif] no terminal tracked for session ${state.session_id} — window focus only`
           );
         }
-        // Note: the in-app showInformationMessage popup will linger here. VS Code does
-        // not expose programmatic dismissal of a specific notification, and attempted
-        // workarounds (notifications.acceptPrimaryAction) did not reliably dismiss it.
-        // Tracked as a known limitation; future work: redesign the in-app UX to use a
-        // mechanism we fully control (e.g. status bar item or withProgress).
+        // Programmatically dismiss the in-app withProgress notification (V2).
+        const dismisser = this.inAppDismissers.get(state.session_id);
+        if (dismisser) {
+          this.outputChannel.appendLine(
+            `[mac-notif] dismissing in-app for session ${state.session_id}`
+          );
+          dismisser();
+        }
       }
       this.activeMacNotifGroups.delete(state.session_id);
     });
@@ -387,6 +438,15 @@ export class NotificationManager {
     }
     this.cancelMacEscalation(sessionId, reason);
     this.activeNotifications.delete(sessionId);
+    this.waitingSessions.delete(sessionId);
+    // Programmatically dismiss the in-app withProgress notification if visible
+    const dismisser = this.inAppDismissers.get(sessionId);
+    if (dismisser) {
+      this.outputChannel.appendLine(
+        `[in-app] dismissing for session ${sessionId} (cancelAll: ${reason})`
+      );
+      dismisser();
+    }
   }
 
   dispose(): void {
@@ -402,6 +462,12 @@ export class NotificationManager {
       this.dismissActiveMacNotif(groupId);
     }
     this.activeMacNotifGroups.clear();
+    // Dismiss any visible in-app notifications first so withProgress promises resolve
+    for (const dismisser of this.inAppDismissers.values()) {
+      dismisser();
+    }
+    this.inAppDismissers.clear();
+    this.waitingSessions.clear();
     this.activeNotifications.clear();
     this._alreadyNotified.clear();
     for (const d of this.disposables) {

--- a/src/notificationManager.ts
+++ b/src/notificationManager.ts
@@ -306,9 +306,27 @@ export class NotificationManager {
         stdoutBuf.includes("activate");
       if (wasClicked) {
         this.outputChannel.appendLine(
-          `[mac-notif] click handler invoked, focusing window at ${workspacePath ?? "(no workspace)"}`
+          `[mac-notif] click handler invoked for session ${state.session_id}`
         );
+        // Bring VS Code app to foreground (from a background space / another app).
         this.focusVSCodeWindow(workspacePath);
+        // Then focus the specific terminal — same as in-app "Focus Terminal" button.
+        const targetTerminal = this.terminalManager.getTerminalForSession(state.session_id);
+        if (targetTerminal) {
+          this.outputChannel.appendLine(
+            `[mac-notif] calling terminal.show() for session ${state.session_id}`
+          );
+          targetTerminal.show();
+        } else {
+          this.outputChannel.appendLine(
+            `[mac-notif] no terminal tracked for session ${state.session_id} — window focus only`
+          );
+        }
+        // Note: the in-app showInformationMessage popup will linger here. VS Code does
+        // not expose programmatic dismissal of a specific notification, and attempted
+        // workarounds (notifications.acceptPrimaryAction) did not reliably dismiss it.
+        // Tracked as a known limitation; future work: redesign the in-app UX to use a
+        // mechanism we fully control (e.g. status bar item or withProgress).
       }
       this.activeMacNotifGroups.delete(state.session_id);
     });

--- a/src/notificationManager.ts
+++ b/src/notificationManager.ts
@@ -180,29 +180,35 @@ export class NotificationManager {
     // Schedule mac escalation in parallel with awaiting in-app interaction
     this.scheduleMacEscalation(state, snippet);
 
-    // V2 — withProgress instead of showInformationMessage so we can dismiss programmatically.
-    // The promise we return controls the notification lifetime:
-    //   - User clicks Cancel → token.onCancellationRequested → resolve → dismiss
-    //   - Mac click handler calls our stored dismisser → resolve → dismiss
-    //   - state -> working → cancelMacEscalation also calls dismisser → resolve → dismiss
-    // VS Code uses its own Cancel button label, which we cannot rename. We treat Cancel
-    // as the "Focus Terminal" action — a slight UX wart, documented in CHANGELOG and #23.
-    let dismissReason: string = "external";
+    // V3 — withProgress with inline command-URI links in the progress message,
+    // emulating real action buttons that programmatically dismiss the notification.
+    // Each "button" is a markdown link that triggers a registered command. The
+    // commands cancel a CancellationTokenSource which resolves the withProgress
+    // promise, naturally dismissing the in-app popup.
+    // Pattern from: https://www.eliostruyf.com/creating-timer-dismissable-notifications-visual-studio-code-extension/
+    const args = encodeURIComponent(JSON.stringify([state.session_id]));
+    const focusLink = `[Focus Terminal](command:heydev.focusSession?${args})`;
+    const replyLink = `[Quick Reply](command:heydev.quickReply?${args})`;
+    const messageText = snippet ? snippet.replace(/^: /, "") : "Needs your attention";
+    // Try multiple line-break syntaxes; VS Code's progress message parser is finicky.
+    // Markdown standard: two trailing spaces + \n. Also try \n\n (paragraph) and <br>.
+    const progressMessage = `${messageText}  \n\n${focusLink} · ${replyLink}`;
+
     await vscode.window.withProgress(
       {
         location: vscode.ProgressLocation.Notification,
-        title: message,
+        title: `[${state.tag}] waiting`,
         cancellable: true,
       },
-      (_progress, token) => {
+      (progress, token) => {
         return new Promise<void>((resolve) => {
+          progress.report({ message: progressMessage });
           this.inAppDismissers.set(state.session_id, () => {
-            dismissReason = "external";
             this.inAppDismissers.delete(state.session_id);
             resolve();
           });
+          // Cancel button (X) on the progress notification dismisses without action
           token.onCancellationRequested(() => {
-            dismissReason = "cancel";
             this.inAppDismissers.delete(state.session_id);
             resolve();
           });
@@ -210,18 +216,13 @@ export class NotificationManager {
       }
     );
 
-    // After in-app dismisses for any reason — cancel mac escalation
-    this.cancelMacEscalation(state.session_id, `in-app dismissed (${dismissReason})`);
+    this.cancelMacEscalation(state.session_id, "in-app dismissed");
     this.activeNotifications.delete(state.session_id);
+    this.waitingSessions.delete(state.session_id);
 
     this.outputChannel.appendLine(
-      `[in-app] dismissed for session ${state.session_id} (${dismissReason})`
+      `[in-app] dismissed for session ${state.session_id}`
     );
-
-    // User-initiated cancel = treat as "Focus Terminal" action
-    if (dismissReason === "cancel" && terminal) {
-      terminal.show();
-    }
   }
 
   /** Public — called by the heydev.quickReply command. Returns the active waiting sessions. */
@@ -229,7 +230,16 @@ export class NotificationManager {
     return [...this.waitingSessions.values()];
   }
 
-  /** Public — send a quick reply to a specific session's terminal. */
+  /** Public — focus the specified session's terminal and dismiss its in-app popup. */
+  focusSession(sessionId: string): void {
+    const terminal = this.terminalManager.getTerminalForSession(sessionId);
+    if (terminal) {
+      terminal.show();
+    }
+    this.dismissInApp(sessionId, "focusSession command");
+  }
+
+  /** Public — send a quick reply to a specific session's terminal, then dismiss its in-app popup. */
   async sendQuickReply(sessionId: string): Promise<void> {
     const state = this.waitingSessions.get(sessionId);
     if (!state) {
@@ -247,6 +257,18 @@ export class NotificationManager {
     });
     if (reply !== undefined && reply.trim() !== "") {
       terminal.sendText(reply.trim());
+    }
+    this.dismissInApp(sessionId, "quickReply command");
+  }
+
+  /** Public — programmatically dismiss the in-app withProgress popup for a session. */
+  dismissInApp(sessionId: string, reason: string): void {
+    const dismisser = this.inAppDismissers.get(sessionId);
+    if (dismisser) {
+      this.outputChannel.appendLine(
+        `[in-app] dismissing for session ${sessionId} (${reason})`
+      );
+      dismisser();
     }
   }
 
@@ -317,7 +339,7 @@ export class NotificationManager {
       "-message", message,
       "-appIcon", iconPath,
       "-group", groupId,
-      "-timeout", "60",
+      "-timeout", "180",
     ];
     if (playSound) args.push("-sound", "default");
 


### PR DESCRIPTION
## Summary

Ships **macOS notification escalation** for HeyDev — closes #19. When the in-app waiting notification is not interacted with, HeyDev fires a native macOS notification. Clicking the macOS notification foregrounds VS Code and focuses the originating session's terminal.

Also redesigns the in-app notification to use `withProgress` with inline `command:` URI links, giving it real action buttons **and** programmatic dismissal — so clicking the macOS notification cleanly dismisses the in-app popup.

## What's in this PR

- **New macOS notification flow.** Bundled `node-notifier` (terminal-notifier.app). Spawned via `child_process.spawn` with `detached: true` because VS Code's hardened-runtime extension host was suppressing notification UI from attached children.
- **In-app redesign.** `withProgress` notification with `Focus Terminal` and `Quick Reply` as markdown command:URI links. Programmatically dismissable (mac click, state→working, or terminal close all close the popup cleanly).
- **New commands** in the palette:
  - `HeyDev: Focus Waiting Session Terminal`
  - `HeyDev: Quick Reply to Waiting Session`
  - `HeyDev: Open Settings`
- **New config:**
  - `heydev.enableMacNotifications` (default `true`)
  - `heydev.macNotificationDelaySeconds` (default `30`)
  - `heydev.macNotificationSound` (default `false`)
- Extensive diagnostic logging in the HeyDev Output Channel.
- `.vscode/launch.json` + `tasks.json` for stable F5 extension development.
- Design spec in `docs/superpowers/specs/2026-05-02-mac-notification-escalation-design.md`.

## What's NOT in this PR (follow-ups)

- macOS notification icon shows Terminal.app icon, not HeyDev's. terminal-notifier's `-appIcon` flag uses a private macOS method that is silently ignored on recent macOS versions. Likely requires a forked terminal-notifier with HeyDev's icon baked into the bundle. Tracked as a known issue in CHANGELOG.
- The existing intermittent in-app "Focus Terminal" bug from previous versions — separate issue, not introduced here.

## Closes

- #19 — macOS notification escalation feature
- #21 — Add HeyDev: Open Settings command
- #23 — Redesign in-app notification for programmatic dismissal

## Test plan

Manual verification on macOS:

- [x] In-app notification appears with `Focus Terminal` and `Quick Reply` clickable links
- [x] Clicking `Focus Terminal` link focuses the correct terminal and dismisses the popup
- [x] Clicking `Quick Reply` link opens an input box and sends the reply
- [x] macOS notification fires after the configured delay if the in-app popup is not interacted with
- [x] Clicking the macOS notification foregrounds VS Code, focuses the terminal, and dismisses the in-app popup
- [x] `[mac-notif] subprocess exited code=0 stdout="@ACTIONCLICKED"` appears in the Output Channel
- [ ] Multiple simultaneous waiting sessions — each gets its own macOS notification, clicks route to the correct terminal (not yet exercised)
- [ ] State→working mid-flight cancels both the in-app and the pending macOS notification (covered by existing logic, not yet re-verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)